### PR TITLE
Fixed "in_view" extension for right & bottom sides

### DIFF
--- a/scripts/in_view.gml
+++ b/scripts/in_view.gml
@@ -9,7 +9,7 @@ var _padding; if (argument_count > 1) _padding = argument[1]; else _padding = 0;
 
 var view_left; view_left = view_xview[view_current] - _padding;
 var view_top; view_top = view_yview[view_current] - _padding;
-var view_right; view_right = view_xview[view_current] + screen_get_width() + _padding;
-var view_bottom; view_bottom = view_yview[view_current] + screen_get_height() + _padding;
+var view_right; view_right = view_xview[view_current] + screen_get_width() + _padding * 2;
+var view_bottom; view_bottom = view_yview[view_current] + screen_get_height() + _padding * 2;
 
 with (_obj) return point_in_rectangle(x, y, view_left, view_top, view_right, view_bottom);


### PR DESCRIPTION
The calculations for the right and bottom sides of the view resulted in a net extension of 0 due to a lack of consideration for the "padding" argument shifting the left and top sides of the view back by the provided amount. This has been corrected by multiplying the "padding" by 2 for the right and bottom sides only.